### PR TITLE
Collection delegate

### DIFF
--- a/lib/burgundy/collection.rb
+++ b/lib/burgundy/collection.rb
@@ -1,10 +1,11 @@
 module Burgundy
-  class Collection
+  class Collection < SimpleDelegator
     include Enumerable
 
     def initialize(items, wrapping_class = nil)
       @items = items
       @wrapping_class = wrapping_class
+      __setobj__(@items)
     end
 
     def empty?

--- a/spec/burgundy_spec.rb
+++ b/spec/burgundy_spec.rb
@@ -27,6 +27,11 @@ describe Burgundy do
     expect(collection.first).to eql(1)
   end
 
+  it 'delegate collection calls' do
+    collection = Burgundy::Collection.new([1,2,3], wrapper)
+    expect(collection.size).to eql(3)
+  end
+
   it 'includes Enumerable' do
     expect(Burgundy::Collection).to include(Enumerable)
   end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -13,7 +13,7 @@ Dummy::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files   = true
   config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching.


### PR DESCRIPTION
When using to wrap an collection of objects that will later be paginated, `Burgundy::Collection` raises a `NoMethodError`. Tried this on both [`kaminari`](https://github.com/amatsuda/kaminari) and [`paginate`](https://github.com/fnando/paginate) gems.

This is due to the fact that common pagination libs may call methods outside the `Enumerator` mixin or one implemented by the lib itself (like `#total_pages`).

Changed `Burgundy::Collection` to also delegate to the collection it wraps.
